### PR TITLE
Break out ecs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ create-foundation: deps upload-templates
 			"ParameterKey=ProjectName,ParameterValue=${PROJECT}" \
 			"ParameterKey=PublicDomainName,ParameterValue=${DOMAIN}" \
 			"ParameterKey=Region,ParameterValue=${REGION}" \
-			"ParameterKey=EcsInstanceType,ParameterValue=t2.small" \
 		--tags \
 			"Key=Environment,Value=${ENV}" \
 			"Key=Owner,Value=${OWNER}" \
@@ -73,8 +72,8 @@ create-foundation: deps upload-templates
 	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-foundation"
 
 ## Create new CF Build pipeline stack
-create-compute: upload-compute-ecs
-	@aws cloudformation create-stack --stack-name "rig.${OWNER}.${PROJECT}.${REGION}.compute-ecs.${ENV}" \
+create-compute: upload-compute
+	@aws cloudformation create-stack --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs" \
                 --region ${REGION} \
                 --disable-rollback \
 		--template-body "file://cloudformation/compute-ecs/main.yaml" \
@@ -82,10 +81,11 @@ create-compute: upload-compute-ecs
 		--parameters \
 			"ParameterKey=FoundationStackName,ParameterValue=${OWNER}-${PROJECT}-${ENV}-foundation" \
 			"ParameterKey=SshKeyName,ParameterValue=${KEY_NAME}" \
+			"ParameterKey=InstanceType,ParameterValue=t2.small" \
 		--tags \
 			"Key=Owner,Value=${OWNER}" \
 			"Key=Project,Value=${PROJECT}"
-	@aws cloudformation wait stack-create-complete --stack-name "rig.${OWNER}.${PROJECT}.${REGION}.compute-ecs.${ENV}"
+	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs"
 
 ## Create new CF Build pipeline stack
 create-build-pipeline: upload-build
@@ -145,7 +145,6 @@ update-foundation: upload-templates
 			"ParameterKey=ProjectName,ParameterValue=${PROJECT}" \
 			"ParameterKey=PublicDomainName,ParameterValue=${DOMAIN}" \
 			"ParameterKey=Region,ParameterValue=${REGION}" \
-			"ParameterKey=EcsInstanceType,ParameterValue=t2.small" \
 			"ParameterKey=SshKeyName,ParameterValue=${KEY_NAME}" \
 		--tags \
 			"Key=Environment,Value=${ENV}" \
@@ -153,20 +152,20 @@ update-foundation: upload-templates
 			"Key=Project,Value=${PROJECT}"
 	@aws cloudformation wait stack-update-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-foundation"
 
-## Update new CF Build pipeline stack
-update-compute: upload-compute-ecs
-	@aws cloudformation update-stack --stack-name "rig.${OWNER}.${PROJECT}.${REGION}.compute-ecs.${ENV}" \
+## Create new CF Build pipeline stack
+update-compute: upload-compute
+	@aws cloudformation update-stack --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs" \
                 --region ${REGION} \
-                --disable-rollback \
 		--template-body "file://cloudformation/compute-ecs/main.yaml" \
 		--capabilities CAPABILITY_NAMED_IAM \
 		--parameters \
 			"ParameterKey=FoundationStackName,ParameterValue=${OWNER}-${PROJECT}-${ENV}-foundation" \
 			"ParameterKey=SshKeyName,ParameterValue=${KEY_NAME}" \
+			"ParameterKey=InstanceType,ParameterValue=t2.small" \
 		--tags \
 			"Key=Owner,Value=${OWNER}" \
 			"Key=Project,Value=${PROJECT}"
-	@aws cloudformation wait stack-update-complete --stack-name "rig.${OWNER}.${PROJECT}.${REGION}.compute-ecs.${ENV}"
+	@aws cloudformation wait stack-update-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs"
 
 ## Update existing Build Pipeline CF Stack
 update-build-pipeline: upload-build
@@ -315,7 +314,7 @@ upload-app-deployment:
 
 ## Upload Compute ECS Templates
 upload-compute-ecs:
-	@aws s3 cp --recursive cloudformation/compute-ecs/ s3://rig.${OWNER}.${PROJECT}.${REGION}.compute-ecs/templates/
+	@aws s3 cp --recursive cloudformation/compute-ecs/ s3://rig.${OWNER}.${PROJECT}.${REGION}.compute-ecs.${ENV}/templates/
 
 ## Upload Build CF Templates
 upload-build:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ create-foundation: deps upload-templates
 			"Key=Environment,Value=${ENV}" \
 			"Key=Owner,Value=${OWNER}" \
 			"Key=Project,Value=${PROJECT}"
-	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-foundation --region ${REGION}"
+	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-foundation" --region ${REGION}
 
 ## Create new CF Build pipeline stack
 create-compute: upload-compute
@@ -85,7 +85,7 @@ create-compute: upload-compute
 		--tags \
 			"Key=Owner,Value=${OWNER}" \
 			"Key=Project,Value=${PROJECT}"
-	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs"
+	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs" --region ${REGION}
 
 ## Create new CF Build pipeline stack
 create-build: upload-build
@@ -109,7 +109,7 @@ create-build: upload-build
 		--tags \
 			"Key=Owner,Value=${OWNER}" \
 			"Key=Project,Value=${PROJECT}"
-	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-build-${REPO}-${REPO_BRANCH} --region ${REGION}"
+	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-build-${REPO}-${REPO_BRANCH}" --region ${REGION}
 
 ## Create new CF Build pipeline stack
 create-app: deps upload-app
@@ -131,7 +131,7 @@ create-app: deps upload-app
 			"Key=Environment,Value=${ENV}" \
 			"Key=Owner,Value=${OWNER}" \
 			"Key=Project,Value=${PROJECT}"
-	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-app-${REPO}-${REPO_BRANCH} --region ${REGION}"
+	@aws cloudformation wait stack-create-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-app-${REPO}-${REPO_BRANCH}" --region ${REGION}
 
 ## Updates existing Foundation CF stack
 update-foundation: upload-templates
@@ -150,7 +150,7 @@ update-foundation: upload-templates
 			"Key=Environment,Value=${ENV}" \
 			"Key=Owner,Value=${OWNER}" \
 			"Key=Project,Value=${PROJECT}"
-	@aws cloudformation wait stack-update-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-foundation --region ${REGION}"
+	@aws cloudformation wait stack-update-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-foundation" --region ${REGION}
 
 ## Create new CF Build pipeline stack
 update-compute: upload-compute
@@ -165,7 +165,7 @@ update-compute: upload-compute
 		--tags \
 			"Key=Owner,Value=${OWNER}" \
 			"Key=Project,Value=${PROJECT}"
-	@aws cloudformation wait stack-update-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs"
+	@aws cloudformation wait stack-update-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs" --region ${REGION}
 
 ## Update existing Build Pipeline CF Stack
 update-build: upload-build
@@ -209,7 +209,7 @@ update-app: deps upload-app
 			"Key=Environment,Value=${ENV}" \
 			"Key=Owner,Value=${OWNER}" \
 			"Key=Project,Value=${PROJECT}"
-	@aws cloudformation wait stack-update-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-app --region ${REGION}"
+	@aws cloudformation wait stack-update-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-app" --region ${REGION}
 
 ## Print Foundation stack's status
 status-foundation:
@@ -259,14 +259,14 @@ outputs-app:
 delete-foundation:
 	@if ${MAKE} .prompt-yesno message="Are you sure you wish to delete the ${ENV} Foundation Stack?"; then \
 		aws cloudformation delete-stack --region ${REGION} --stack-name "${OWNER}-${PROJECT}-${ENV}-foundation"; \
-		aws cloudformation wait stack-delete-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-foundation --region ${REGION}"; \
+		aws cloudformation wait stack-delete-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-foundation" --region ${REGION}; \
 	fi
 
 ## Deletes the Foundation CF stack
 delete-compute:
 	@if ${MAKE} .prompt-yesno message="Are you sure you wish to delete the ${ENV} Compute Stack?"; then \
 		aws cloudformation delete-stack --region ${REGION} --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs"; \
-		aws cloudformation wait stack-delete-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs"; \
+		aws cloudformation wait stack-delete-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-compute-ecs" --region ${REGION}; \
 	fi
 
 ## Deletes the build pipeline CF stack
@@ -279,14 +279,14 @@ delete-build:
 	fi;
 	@if ${MAKE} .prompt-yesno message="Are you sure you wish to delete the ${PROJECT} Pipeline Stack for repo: ${REPO} branch: ${REPO_BRANCH}?"; then \
 		aws cloudformation delete-stack --region ${REGION} --stack-name "${OWNER}-${PROJECT}-build-${REPO}-${REPO_BRANCH}"; \
-		aws cloudformation wait stack-delete-complete --stack-name "${OWNER}-${PROJECT}-build-${REPO}-${REPO_BRANCH} --region ${REGION}"; \
+		aws cloudformation wait stack-delete-complete --stack-name "${OWNER}-${PROJECT}-build-${REPO}-${REPO_BRANCH}" --region ${REGION}; \
 	fi
 
 ## Deletes the app CF stack
 delete-app:
 	@if ${MAKE} .prompt-yesno message="Are you sure you wish to delete the App Stack for environment: ${ENV} repo: ${REPO} branch: ${REPO_BRANCH}?"; then \
 		aws cloudformation delete-stack --region ${REGION} --stack-name "${OWNER}-${PROJECT}-${ENV}-app-${REPO}-${REPO_BRANCH}"; \
-		aws cloudformation wait stack-delete-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-app-${REPO}-${REPO_BRANCH} --region ${REGION}"; \
+		aws cloudformation wait stack-delete-complete --stack-name "${OWNER}-${PROJECT}-${ENV}-app-${REPO}-${REPO_BRANCH}" --region ${REGION}; \
 	fi
 
 upload-templates: upload-foundation upload-app

--- a/README.md
+++ b/README.md
@@ -40,13 +40,16 @@ REGION = us-east-1
 Confirm everything is valid with `make check-env`
 
 ## Makefile Targets
-
-* Run `make create-foundation ENV=integration` to start an AWS Bare Rig Foundation Stack.  This is syncrhonous and will wait until the stack is created (or fails).  This is the Stack that will be shared by all management and services in an AWS Region.
-  * The Build Pipeline requires an "integration" environment.
-* Run `make status-foundation ENV=integration` to check status of the stack. (Should be `CREATE_COMPLETE`)
-* Check the outputs as well with `make outputs-foundation ENV=integration`
+The full build pipeline requires at least integration, staging, and production environments, so the typical
+installation is: 
+* Run `make create-foundation ENV=integration`
+* Run `make create-compute ENV=integration`
 * Run `make create-foundation ENV=staging`
+* Run `make create-compute ENV=staging`
 * Run `make create-foundation ENV=production`
+* Run `make create-compute ENV=production`
+* Check the outputs of the above with `make outputs-foundation ENV=<environment>`
+* Check the status of the above with `make status-foundation ENV=<environment>`
 * Run `make create-build-pipeline REPO=<repo_name> REPO_BRANCH=<branch> CONTAINER_PORT=<port> LISTENER_RULE_PRIORITY=<priority>`, same options for status: `make status-build-pipeline` and outputs `make outputs-build-pipeline`
   * REPO is the repo that hangs off buildit organization (e.g "bookit-api")
   * CONTAINER_PORT is the port that the application exposes (e.g. 8080)
@@ -58,6 +61,7 @@ To delete everything, in order:
 * Run `make delete-app ENV=<environment> REPO=<repo_name> REPO_BRANCH=<branch>` to delete the App stacks.
   * if you deleted the pipeline first, you'll find you can't delete the app stacks because the role that created them is gone.  You'll have to manually delete via aws cli and the `--role-arn` override
 * Run `make delete-build-pipeline REPO=<repo_name> REPO_BRANCH=<branch>` to delete the Pipline stack.
+* Run `make delete-compute ENV=<environment>` to delete the Compute stack.
 * Run `make delete-foundation ENV=<environment>` to delete the Foundation stack.
 * Run `make delete-deps ENV=<environment>` to delete the required S3 buckets.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For using this repo you'll need:
 This can either be done by copying settings from the template `.make.example`
 and save in a new file `.make`:
 
-```
+```ini
 DOMAIN = <Domain to use for Foundation>
 KEY_NAME = <EC2 SSH key name>
 OWNER = <The owner of the stack, either personal or corporate>
@@ -27,7 +27,8 @@ REPO_TOKEN = <Github OAuth or Personal Access Token>
 Or also done interactively through `make .make`.
 
 For the "real" bookit riglet:
-```
+
+```ini
 DOMAIN = buildit.tools
 KEY_NAME = buildit-bookit-ssh-keypair
 OWNER = buildit
@@ -40,12 +41,15 @@ REGION = us-east-1
 Confirm everything is valid with `make check-env`
 
 ## Feeling Lucky?
- - `./create-standard-riglet.sh` to create a full riglet with standard environments.
- - `./delete-standard-riglet.sh` to delete it all.
+
+* `./create-standard-riglet.sh` to create a full riglet with standard environments.
+* `./delete-standard-riglet.sh` to delete it all.
 
 ## Makefile Targets
+
 The full build pipeline requires at least integration, staging, and production environments, so the typical
-installation is: 
+installation is:
+
 * Run `make create-foundation ENV=integration`
 * Run `make create-compute ENV=integration`
 * Run `make create-foundation ENV=staging`
@@ -54,7 +58,7 @@ installation is:
 * Run `make create-compute ENV=production`
 * Check the outputs of the above with `make outputs-foundation ENV=<environment>`
 * Check the status of the above with `make status-foundation ENV=<environment>`
-* Run `make create-build-pipeline REPO=<repo_name> REPO_BRANCH=<branch> CONTAINER_PORT=<port> LISTENER_RULE_PRIORITY=<priority>`, same options for status: `make status-build-pipeline` and outputs `make outputs-build-pipeline`
+* Run `make create-build REPO=<repo_name> REPO_BRANCH=<branch> CONTAINER_PORT=<port> LISTENER_RULE_PRIORITY=<priority>`, same options for status: `make status-build` and outputs `make outputs-build`
   * REPO is the repo that hangs off buildit organization (e.g "bookit-api")
   * REPO_BRANCH is the branch name for the repo - MUST NOT CONTAIN SLASHES!
   * CONTAINER_PORT is the port that the application exposes (e.g. 8080)
@@ -65,7 +69,7 @@ To delete everything, in order:
 
 * Run `make delete-app ENV=<environment> REPO=<repo_name> REPO_BRANCH=<branch>` to delete the App stacks.
   * if you deleted the pipeline first, you'll find you can't delete the app stacks because the role that created them is gone.  You'll have to manually delete via aws cli and the `--role-arn` override
-* Run `make delete-build-pipeline REPO=<repo_name> REPO_BRANCH=<branch>` to delete the Pipline stack.
+* Run `make delete-build REPO=<repo_name> REPO_BRANCH=<branch>` to delete the Pipline stack.
 * Run `make delete-compute ENV=<environment>` to delete the Compute stack.
 * Run `make delete-foundation ENV=<environment>` to delete the Foundation stack.
 * Run `make delete-deps ENV=<environment>` to delete the required S3 buckets.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ REGION = us-east-1
 
 Confirm everything is valid with `make check-env`
 
+## Feeling Lucky?
+ - `./create-standard-riglet.sh` to create a full riglet with standard environments.
+ - `./delete-standard-riglet.sh` to delete it all.
+
 ## Makefile Targets
 The full build pipeline requires at least integration, staging, and production environments, so the typical
 installation is: 

--- a/cloudformation/app/app.yaml
+++ b/cloudformation/app/app.yaml
@@ -44,7 +44,7 @@ Parameters:
   ContainerPort:
     Type: Number
 
-  DesiredCount:
+  TaskDesiredCount:
     Type: Number
     Default: 0
 
@@ -181,7 +181,7 @@ Resources:
   #     TemplateURL: !Sub https://s3.amazonaws.com/${InfraDevBucket}/templates/service.yaml
   #     Parameters:
   #       Tag: !Sub "${Environment}"
-  #       DesiredCount: 0
+  #       TaskDesiredCount: 0
   #       Cluster: !Ref Cluster
   #       TargetGroup: !GetAtt LoadBalancer.Outputs.TargetGroup
   #       Repository: !Ref Repository
@@ -208,7 +208,7 @@ Resources:
       Cluster:
         Fn::ImportValue: !Sub "${ComputeStackName}--Cluster"
       Role: !Ref ECSServiceRole
-      DesiredCount: !Ref DesiredCount
+      DesiredCount: !Ref TaskDesiredCount
       TaskDefinition: !Ref TaskDefinition
       LoadBalancers:
         - ContainerName: !Ref ApplicationName

--- a/cloudformation/app/app.yaml
+++ b/cloudformation/app/app.yaml
@@ -12,6 +12,10 @@ Parameters:
     Description: Foundation stack name
     Type: String
 
+  ComputeStackName:
+    Description: Compute stack name
+    Type: String
+
   InfraDevBucket:
     Description: App S3 Bucket
     Type: String
@@ -202,7 +206,7 @@ Resources:
     Type: AWS::ECS::Service
     Properties:
       Cluster:
-        Fn::ImportValue: !Sub "${FoundationStackName}--Cluster"
+        Fn::ImportValue: !Sub "${ComputeStackName}--Cluster"
       Role: !Ref ECSServiceRole
       DesiredCount: !Ref DesiredCount
       TaskDefinition: !Ref TaskDefinition

--- a/cloudformation/build/deployment-pipeline.yaml
+++ b/cloudformation/build/deployment-pipeline.yaml
@@ -289,6 +289,7 @@ Resources:
                   {
                     "Environment": "integration",
                     "FoundationStackName": "${AppStackName}-integration-foundation",
+                    "ComputeStackName": "${AppStackName}-integration-compute-ecs",
                     "InfraDevBucket": "${InfraDevBucketBase}.integration",
                     "PublicDomainName": "${PublicDomainName}",
                     "Repository": "${Repository}",
@@ -324,6 +325,7 @@ Resources:
                   {
                     "Environment": "staging",
                     "FoundationStackName": "${AppStackName}-staging-foundation",
+                    "ComputeStackName": "${AppStackName}-staging-compute-ecs",
                     "InfraDevBucket": "${InfraDevBucketBase}.staging",
                     "PublicDomainName": "${PublicDomainName}",
                     "Repository": "${Repository}",
@@ -362,6 +364,7 @@ Resources:
                   {
                     "Environment": "production",
                     "FoundationStackName": "${AppStackName}-production-foundation",
+                    "ComputeStackName": "${AppStackName}-production-compute-ecs",
                     "InfraDevBucket": "${InfraDevBucketBase}.production",
                     "PublicDomainName": "${PublicDomainName}",
                     "Repository": "${Repository}",

--- a/cloudformation/build/deployment-pipeline.yaml
+++ b/cloudformation/build/deployment-pipeline.yaml
@@ -296,7 +296,7 @@ Resources:
                     "ApplicationName": "${ApplicationName}",
                     "Prefix": "${Prefix}",
                     "ContainerPort": "${ContainerPort}",
-                    "DesiredCount":"1",
+                    "TaskDesiredCount":"1",
                     "ListenerRulePriority": "${ListenerRulePriority}",
                     "Tag": { "Fn::GetParam" : [ "BuildOutput", "build.json", "tag" ] }
                   }
@@ -332,7 +332,7 @@ Resources:
                     "ApplicationName": "${ApplicationName}",
                     "Prefix": "${Prefix}",
                     "ContainerPort": "${ContainerPort}",
-                    "DesiredCount":"1",
+                    "TaskDesiredCount":"1",
                     "ListenerRulePriority": "${ListenerRulePriority}",
                     "Tag": { "Fn::GetParam" : [ "BuildOutput", "build.json", "tag" ] }
                   }
@@ -371,7 +371,7 @@ Resources:
                     "ApplicationName": "${ApplicationName}",
                     "Prefix": "${Prefix}",
                     "ContainerPort": "${ContainerPort}",
-                    "DesiredCount":"1",
+                    "TaskDesiredCount":"1",
                     "ListenerRulePriority": "${ListenerRulePriority}",
                     "Tag": { "Fn::GetParam" : [ "BuildOutput", "build.json", "tag" ] }
                   }

--- a/cloudformation/compute-ecs/main.yaml
+++ b/cloudformation/compute-ecs/main.yaml
@@ -4,6 +4,10 @@ Description: ECS Cluster
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
+  FoundationStackName:
+    Description: Foundation stack name
+    Type: String
+
   ClusterSize:
     Type: Number
     Default: 1
@@ -14,14 +18,12 @@ Parameters:
 
   InstanceType:
     Type: String
-    Default: t2.medium
-
-  FoundationStackName:
-    Description: Foundation stack name
-    Type: String
-
-  SourceSecurityGroup:
-    Type: AWS::EC2::SecurityGroup::Id
+    Default: t2.small
+    AllowedValues:
+      - t2.small
+      - t2.medium
+      - t2.large
+      - t2.xlarge
 
   SshKeyName:
     Type: AWS::EC2::KeyPair::KeyName
@@ -80,7 +82,8 @@ Resources:
     Properties:
       GroupDescription: !Sub ${AWS::StackName}-hosts
       SecurityGroupIngress:
-        - SourceSecurityGroupId: !Ref SourceSecurityGroup
+        - SourceSecurityGroupId:
+            Fn::ImportValue: !Sub "${FoundationStackName}--ALB--SecurityGroup"
           IpProtocol: -1
       VpcId:
         Fn::ImportValue: !Sub "${FoundationStackName}--VpcId"

--- a/cloudformation/compute-ecs/main.yaml
+++ b/cloudformation/compute-ecs/main.yaml
@@ -5,7 +5,7 @@ AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
   FoundationStackName:
-    Description: Foundation stack name
+    Description: Foundation stack name upon which this cluster is installed.
     Type: String
 
   ClusterSize:
@@ -83,7 +83,7 @@ Resources:
       GroupDescription: !Sub ${AWS::StackName}-hosts
       SecurityGroupIngress:
         - SourceSecurityGroupId:
-            Fn::ImportValue: !Sub "${FoundationStackName}--ALB--SecurityGroup"
+            Fn::ImportValue: !Sub "${FoundationStackName}--ALB--SG"
           IpProtocol: -1
       VpcId:
         Fn::ImportValue: !Sub "${FoundationStackName}--VpcId"
@@ -91,7 +91,7 @@ Resources:
   Cluster:
     Type: AWS::ECS::Cluster
     Properties:
-      ClusterName: !Sub ${FoundationStackName}-ECSCluster
+      ClusterName: !Sub ${AWS::StackName}-ECSCluster
 
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -166,5 +166,7 @@ Resources:
 Outputs:
   ClusterName:
     Export:
-      Name: !Sub "${FoundationStackName}--Cluster"
+      Name: !Sub "${AWS::StackName}--Cluster"
     Value: !Ref Cluster
+  AutoScalingGroup:
+    Value: !Ref AutoScalingGroup

--- a/cloudformation/foundation/main.yaml
+++ b/cloudformation/foundation/main.yaml
@@ -140,3 +140,10 @@ Outputs:
   FoundationVpcId:
     Description: VPC Id
     Value: !GetAtt Vpc.Outputs.VpcId
+
+  PublicLoadBalancerSecurityGroup:
+    Export:
+      Name: !Sub "${FoundationStackName}--ALB--SecurityGroup"
+    Description: Security group of public load balancer
+    Value: !GetAtt LoadBalancer.Outputs.SecurityGroup
+

--- a/cloudformation/foundation/main.yaml
+++ b/cloudformation/foundation/main.yaml
@@ -5,11 +5,6 @@ Description: AWS Foundation Template
 
 
 Parameters:
-  AvailabilityZones:
-    Default: us-east-1a,us-east-1b
-    Description: Comma-delimited list of availabilty zones
-    Type: CommaDelimitedList
-
   Environment:
     Description: Stack environment
     Type: String
@@ -44,19 +39,6 @@ Parameters:
     AllowedValues:
       - no
       - yes
-
-  EcsClusterSize:
-    Type: Number
-    Default: 1
-
-  EcsInstanceType:
-    Default: t2.medium
-    Description: Instance type of ECS cluster instance(s)
-    Type: String
-
-  SshKeyName:
-    Description: Name of keypair to use with managed instances.
-    Type: AWS::EC2::KeyPair::KeyName
 
 
 Conditions:
@@ -122,28 +104,14 @@ Resources:
       Parameters:
         FoundationStackName: !Sub ${AWS::StackName}
 
-  Cluster:
-    DependsOn:
-      - LoadBalancer
-    Type: AWS::CloudFormation::Stack
-    Properties:
-      TemplateURL: !Sub https://s3.amazonaws.com/${FoundationBucket}/templates/ecs-cluster.yaml
-      Parameters:
-        FoundationStackName: !Sub ${AWS::StackName}
-        SourceSecurityGroup: !GetAtt LoadBalancer.Outputs.SecurityGroup
-        InstanceType: !Ref EcsInstanceType
-        ClusterSize: !Ref EcsClusterSize
-        SshKeyName: !Ref SshKeyName
-
-
 Outputs:
   FoundationVpcId:
     Description: VPC Id
     Value: !GetAtt Vpc.Outputs.VpcId
 
   PublicLoadBalancerSecurityGroup:
-    Export:
-      Name: !Sub "${FoundationStackName}--ALB--SecurityGroup"
     Description: Security group of public load balancer
     Value: !GetAtt LoadBalancer.Outputs.SecurityGroup
+    Export:
+      Name: !Sub "${AWS::StackName}--ALB--SG"
 

--- a/create-standard-riglet.sh
+++ b/create-standard-riglet.sh
@@ -7,6 +7,7 @@ cat .make
 
 printf  "\n${YELLOW}This command creates a full riglet based on the environment described above.${NC}\n"
 read -p "Are you sure you want to proceed?  " -n 1 -r
+echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
   echo "Y" | make create-foundation ENV=integration

--- a/create-standard-riglet.sh
+++ b/create-standard-riglet.sh
@@ -16,5 +16,6 @@ then
   echo "Y" | make create-compute ENV=staging && \
   echo "Y" | make create-foundation ENV=production && \
   echo "Y" | make create-compute ENV=production && \
-  echo "Y" | make create-build REPO=bookit-api REPO_BRANCH=master CONTAINER_PORT=8080 LISTENER_RULE_PRIORITY=10
+  echo "Y" | make create-build REPO=bookit-api REPO_BRANCH=master CONTAINER_PORT=8080 LISTENER_RULE_PRIORITY=100
+  echo "Y" | make create-build REPO=bookit-client-react REPO_BRANCH=master CONTAINER_PORT=4200 LISTENER_RULE_PRIORITY=200
 fi

--- a/create-standard-riglet.sh
+++ b/create-standard-riglet.sh
@@ -10,12 +10,11 @@ read -p "Are you sure you want to proceed?  " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-  echo "Y" | make create-foundation ENV=integration
-  echo "Y" | make create-compute ENV=integration
-  echo "Y" | make create-foundation ENV=staging
-  echo "Y" | make create-compute ENV=staging
-  echo "Y" | make create-foundation ENV=production
-  echo "Y" | make create-compute ENV=production
-
+  echo "Y" | make create-foundation ENV=integration && \
+  echo "Y" | make create-compute ENV=integration && \
+  echo "Y" | make create-foundation ENV=staging && \
+  echo "Y" | make create-compute ENV=staging && \
+  echo "Y" | make create-foundation ENV=production && \
+  echo "Y" | make create-compute ENV=production && \
   echo "Y" | make create-build REPO=bookit-api REPO_BRANCH=master CONTAINER_PORT=8080 LISTENER_RULE_PRIORITY=10
 fi

--- a/create-standard-riglet.sh
+++ b/create-standard-riglet.sh
@@ -9,11 +9,11 @@ printf  "\n${YELLOW}This command creates a full riglet based on the environment 
 read -p "Are you sure you want to proceed?  " -n 1 -r
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-#  echo "Y" | make create-foundation ENV=integration
+  echo "Y" | make create-foundation ENV=integration
   echo "Y" | make create-compute ENV=integration
-#  echo "Y" | make create-foundation ENV=staging
+  echo "Y" | make create-foundation ENV=staging
   echo "Y" | make create-compute ENV=staging
-#  echo "Y" | make create-foundation ENV=production
+  echo "Y" | make create-foundation ENV=production
   echo "Y" | make create-compute ENV=production
 
   echo "Y" | make create-build REPO=bookit-api REPO_BRANCH=master CONTAINER_PORT=8080 LISTENER_RULE_PRIORITY=10

--- a/create-standard-riglet.sh
+++ b/create-standard-riglet.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+cat .make
+
+printf  "\n${YELLOW}This command creates a full riglet based on the environment described above.${NC}\n"
+read -p "Are you sure you want to proceed?  " -n 1 -r
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+#  echo "Y" | make create-foundation ENV=integration
+  echo "Y" | make create-compute ENV=integration
+#  echo "Y" | make create-foundation ENV=staging
+  echo "Y" | make create-compute ENV=staging
+#  echo "Y" | make create-foundation ENV=production
+  echo "Y" | make create-compute ENV=production
+
+  echo "Y" | make create-build REPO=bookit-api REPO_BRANCH=master CONTAINER_PORT=8080 LISTENER_RULE_PRIORITY=10
+fi

--- a/delete-standard-riglet.sh
+++ b/delete-standard-riglet.sh
@@ -17,8 +17,13 @@ then
   echo "Y" | make delete-app ENV=integration REPO=bookit-api REPO_BRANCH=${BRANCH}
   echo "Y" | make delete-app ENV=staging REPO=bookit-api REPO_BRANCH=${BRANCH}
   echo "Y" | make delete-app ENV=production REPO=bookit-api REPO_BRANCH=${BRANCH}
+  echo "Y" | make delete-build REPO=bookit-api REPO_BRANCH=${BRANCH}
 
-  echo "Y" | make delete-build REPO=bookit-api REPO_BRANCH=${BRANCH} CONTAINER_PORT=8080 LISTENER_RULE_PRIORITY=10
+  echo "Y" | make delete-app ENV=integration REPO=bookit-client-react REPO_BRANCH=${BRANCH}
+  echo "Y" | make delete-app ENV=staging REPO=bookit-client-react REPO_BRANCH=${BRANCH}
+  echo "Y" | make delete-app ENV=production REPO=bookit-client-react REPO_BRANCH=${BRANCH}
+  echo "Y" | make delete-build REPO=bookit-client-react REPO_BRANCH=${BRANCH}
+
   echo "Y" | make delete-compute ENV=integration
   echo "Y" | make delete-foundation ENV=integration
   echo "Y" | make delete-compute ENV=staging

--- a/delete-standard-riglet.sh
+++ b/delete-standard-riglet.sh
@@ -11,7 +11,7 @@ printf "\n${YELLOW}***${NC} For a clean deletion you must delete the images cont
 
 printf "${RED}This will delete the riglet environment described above.${NC}\n"
 read -p "Are you sure you want to proceed?  " -n 1 -r
-echo    # (optional) move to a new line
+echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
   echo "Y" | make delete-app ENV=integration REPO=bookit-api REPO_BRANCH=${BRANCH}

--- a/delete-standard-riglet.sh
+++ b/delete-standard-riglet.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+BRANCH=master
+
+cat .make
+
+printf "\n${YELLOW}***${NC} For a clean deletion you must delete the images contained in the ECS repo for this riglet.\n\n"
+
+printf "${RED}This will delete the riglet environment described above.${NC}\n"
+read -p "Are you sure you want to proceed?  " -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  echo "Y" | make delete-app ENV=integration REPO=bookit-api REPO_BRANCH=${BRANCH}
+  echo "Y" | make delete-app ENV=staging REPO=bookit-api REPO_BRANCH=${BRANCH}
+  echo "Y" | make delete-app ENV=production REPO=bookit-api REPO_BRANCH=${BRANCH}
+
+  echo "Y" | make delete-build REPO=bookit-api REPO_BRANCH=${BRANCH} CONTAINER_PORT=8080 LISTENER_RULE_PRIORITY=10
+  echo "Y" | make delete-compute ENV=integration
+  echo "Y" | make delete-foundation ENV=integration
+  echo "Y" | make delete-compute ENV=staging
+  echo "Y" | make delete-foundation ENV=staging
+  echo "Y" | make delete-compute ENV=production
+  echo "Y" | make delete-foundation ENV=production
+fi


### PR DESCRIPTION
This actually adds a couple of things:
 - Moving toward a more layered approach with the introduction of a "compute" layer (implemented as ECS in this case).  The idea is that alternate compute layers (e.g. Elastic Beanstalk) could be implemented into alternate rigs, if approached correctly.  This is not a completely thought-through implementation, but the expression of a philosophy.  One could imagine stacking on a "storage" or "persistence" layer, a "cache" layer, etc.
 - Generification of Makefile target names, furthering the above: there might be different implementations of the targets someday (in some other rig).
 - A couple of mega-scripts to help bring up and shut down an entire "standard" riglet.
 - Some random other stuff here and there.