### PR TITLE
Parameratize Domain Certificate

### DIFF
--- a/.make.example
+++ b/.make.example
@@ -4,3 +4,4 @@ OWNER = jdoe
 PROFILE = default
 PROJECT = mycoolproject
 REGION = us-east-1
+DOMAIN_CERT = 0663e927-e990-4157-aef9-7dea87faa6ec

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ export PROJECT ?= projectname
 export REGION ?= us-east-1
 export PREFIX ?= ${OWNER}
 export REPO_BRANCH ?= master
+export DOMAIN_CERT ?= ""
 
 export AWS_PROFILE=${PROFILE}
 export AWS_REGION=${REGION}
@@ -110,6 +111,7 @@ create-foundation: create-foundation-deps upload-templates
 			"ParameterKey=ProjectName,ParameterValue=${PROJECT}" \
 			"ParameterKey=PublicDomainName,ParameterValue=${DOMAIN}" \
 			"ParameterKey=Region,ParameterValue=${REGION}" \
+			"ParameterKey=DomainCertGuid,ParameterValue=${DOMAIN_CERT}" \
 		--tags \
 			"Key=Environment,Value=${ENV}" \
 			"Key=Owner,Value=${OWNER}" \
@@ -407,6 +409,9 @@ ifndef PROJECT
 endif
 ifndef REGION
 	$(error REGION is undefined, should be in file .make)
+endif
+ifndef DOMAIN_CERT
+	$(error DOMAIN_CERT is undefined, should be in file .make)
 endif
 	@echo "All required ENV vars set"
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ OWNER = buildit
 PROFILE = default
 PROJECT = bookit
 REGION = us-east-1
-DOMAIN_CERT = 5346c0ef-a307-41c3-a027-208f70992318
+DOMAIN_CERT = 0663e927-e990-4157-aef9-7dea87faa6ec
 PREFIX =
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ OWNER = <The owner of the stack, either personal or corporate>
 PROFILE = <AWS Profile Name>
 PROJECT = <Project Name>
 REGION = <AWS Region>
+DOMAIN_CERT = <AWS Certificate Manager GUID>
 ```
 
 Or also done interactively through `make .make`.
@@ -34,6 +35,7 @@ OWNER = buildit
 PROFILE = default
 PROJECT = bookit
 REGION = us-east-1
+DOMAIN_CERT = 5346c0ef-a307-41c3-a027-208f70992318
 PREFIX =
 ```
 

--- a/cloudformation/foundation/load-balancer.yaml
+++ b/cloudformation/foundation/load-balancer.yaml
@@ -8,6 +8,14 @@ Parameters:
     Description: Foundation stack name
     Type: String
 
+  Region:
+    Description: AWS Region ID
+    Type: String
+
+  DomainCertGuid:
+    Description: GUID for Domain ARN
+    Type: String
+
 Resources:
   SecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
@@ -39,7 +47,7 @@ Resources:
     Properties:
       LoadBalancerArn: !Ref LoadBalancer
       Certificates:
-        - CertificateArn: arn:aws:acm:us-east-1:006393696278:certificate/0663e927-e990-4157-aef9-7dea87faa6ec
+        - CertificateArn: !Sub "arn:aws:acm:${Region}:006393696278:certificate/${DomainCertGuid}"
       Port: 443
       Protocol: HTTPS
       DefaultActions:

--- a/cloudformation/foundation/load-balancer.yaml
+++ b/cloudformation/foundation/load-balancer.yaml
@@ -8,10 +8,6 @@ Parameters:
     Description: Foundation stack name
     Type: String
 
-  Region:
-    Description: AWS Region ID
-    Type: String
-
   DomainCertGuid:
     Description: GUID for Domain ARN
     Type: String
@@ -47,7 +43,7 @@ Resources:
     Properties:
       LoadBalancerArn: !Ref LoadBalancer
       Certificates:
-        - CertificateArn: !Sub "arn:aws:acm:${Region}:006393696278:certificate/${DomainCertGuid}"
+        - CertificateArn: !Sub "arn:aws:acm:${AWS::Region}:006393696278:certificate/${DomainCertGuid}"
       Port: 443
       Protocol: HTTPS
       DefaultActions:

--- a/cloudformation/foundation/main.yaml
+++ b/cloudformation/foundation/main.yaml
@@ -32,6 +32,10 @@ Parameters:
     Description: Region
     Type: String
 
+  DomainCertGuid:
+    Description: GUID for the Cert for the Domain
+    Type: String
+
   CreateHostedZone:
     Default: no
     Description: Whether a new Route 53 hosted zone should be created for this stack.
@@ -103,6 +107,8 @@ Resources:
       TemplateURL: !Sub https://s3.amazonaws.com/${FoundationBucket}/templates/load-balancer.yaml
       Parameters:
         FoundationStackName: !Sub ${AWS::StackName}
+        Region: !Ref Region
+        DomainCertGuid: !Ref DomainCertGuid
 
 Outputs:
   FoundationVpcId:
@@ -114,4 +120,3 @@ Outputs:
     Value: !GetAtt LoadBalancer.Outputs.SecurityGroup
     Export:
       Name: !Sub "${AWS::StackName}--ALB--SG"
-

--- a/cloudformation/foundation/main.yaml
+++ b/cloudformation/foundation/main.yaml
@@ -107,7 +107,6 @@ Resources:
       TemplateURL: !Sub https://s3.amazonaws.com/${FoundationBucket}/templates/load-balancer.yaml
       Parameters:
         FoundationStackName: !Sub ${AWS::StackName}
-        Region: !Ref Region
         DomainCertGuid: !Ref DomainCertGuid
 
 Outputs:

--- a/scripts/build-dotmake.sh
+++ b/scripts/build-dotmake.sh
@@ -9,6 +9,7 @@ read -p 'AWS Profile: ' profile
 read -p 'Project: ' project
 read -p 'Repository OAuth token: ' repo_token
 read -p 'AWS region: ' region
+read -p 'AWS Certificate Manager GUID: ' domain_guid
 echo
 
 cat << EOF > .make
@@ -19,6 +20,7 @@ PROFILE = ${profile}
 PROJECT = ${project}
 REPO_TOKEN = ${repo_token}
 REGION = ${region}
+DOMAIN_CERT = ${domain_guid}
 EOF
 
 echo 'Saved .make!'

--- a/scripts/build-dotmake.sh
+++ b/scripts/build-dotmake.sh
@@ -7,7 +7,6 @@ read -p 'AWS SSH keyname: ' keyname
 read -p 'Owner of riglet: ' owner
 read -p 'AWS Profile: ' profile
 read -p 'Project: ' project
-read -p 'Repository OAuth token: ' repo_token
 read -p 'AWS region: ' region
 read -p 'AWS Certificate Manager GUID: ' domain_guid
 echo
@@ -18,7 +17,6 @@ KEY_NAME = ${keyname}
 OWNER = ${owner}
 PROFILE = ${profile}
 PROJECT = ${project}
-REPO_TOKEN = ${repo_token}
 REGION = ${region}
 DOMAIN_CERT = ${domain_guid}
 EOF


### PR DESCRIPTION
You need a valid cert for the load balancer, but the code assumed 'buildit.tools' in us-east-1.  Created parameters to allow other certs for other regions.  Requires AWS Certificate Manager cert.  Uses the GUID to bulid the path.  Still assumes Builtit account id.