### PR TITLE
Add explicit region to foundation scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ create-foundation: create-foundation-deps upload-templates
 			"ParameterKey=ProjectName,ParameterValue=${PROJECT}" \
 			"ParameterKey=PublicDomainName,ParameterValue=${DOMAIN}" \
 			"ParameterKey=EmailAddress,ParameterValue=${EMAIL_ADDRESS}" \
+			"ParameterKey=Region,ParameterValue=${REGION}" \
 			"ParameterKey=DomainCertGuid,ParameterValue=${DOMAIN_CERT}" \
 		--tags \
 			"Key=Environment,Value=${ENV}" \

--- a/cloudformation/foundation/load-balancer.yaml
+++ b/cloudformation/foundation/load-balancer.yaml
@@ -8,6 +8,10 @@ Parameters:
     Description: Foundation stack name
     Type: String
 
+  Region:
+    Description: AWS Region ID
+    Type: String
+
   DomainCertGuid:
     Description: GUID for Domain ARN
     Type: String
@@ -43,7 +47,7 @@ Resources:
     Properties:
       LoadBalancerArn: !Ref LoadBalancer
       Certificates:
-        - CertificateArn: !Sub "arn:aws:acm:${AWS::Region}:006393696278:certificate/${DomainCertGuid}"
+        - CertificateArn: !Sub "arn:aws:acm:${Region}:006393696278:certificate/${DomainCertGuid}"
       Port: 443
       Protocol: HTTPS
       DefaultActions:

--- a/cloudformation/foundation/main.yaml
+++ b/cloudformation/foundation/main.yaml
@@ -32,6 +32,10 @@ Parameters:
     Type: String
     Default: ""
 
+  Region:
+    Description: AWS Region
+    Type: String
+
   DomainCertGuid:
     Description: GUID for the Cert for the Domain
     Type: String
@@ -70,7 +74,7 @@ Resources:
         CidrBlock: !FindInMap [ EnvironmentToCidr, !Ref Environment, CidrBlock ]
         Environment: !Ref Environment
         FoundationStackName: !Sub ${AWS::StackName}
-        Region: !Sub ${AWS::Region}
+        Region: !Sub ${Region}
         SubnetPrivateCidrBlocks: !FindInMap [ EnvironmentToCidr, !Ref Environment, SubnetPrivateCidrBlocks ]
         SubnetPublicCidrBlocks: !FindInMap [ EnvironmentToCidr, !Ref Environment, SubnetPublicCidrBlocks ]
         InternalHostedZoneName: !Sub "${ProjectName}.internal"
@@ -106,6 +110,7 @@ Resources:
       TemplateURL: !Sub https://s3.amazonaws.com/${FoundationBucket}/templates/load-balancer.yaml
       Parameters:
         FoundationStackName: !Sub ${AWS::StackName}
+        Region: !Ref Region
         DomainCertGuid: !Ref DomainCertGuid
 
   Sns:


### PR DESCRIPTION
Use Region from .make file to create foundation elements in the specified region.  (as opposed to relying on a default configured in the AWS CLI installation.
